### PR TITLE
Circumvent broken JS validation for text fields in surveys

### DIFF
--- a/app/views/decidim/forms/questionnaires/answers/_short_answer.html.erb
+++ b/app/views/decidim/forms/questionnaires/answers/_short_answer.html.erb
@@ -1,0 +1,1 @@
+<%= answer_form.text_field :body, label: false, id: field_id, disabled: disabled, maxlength: maxlength, required: false %>

--- a/config/initializers/decidim_zuerich_customization.rb
+++ b/config/initializers/decidim_zuerich_customization.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative '../../lib/customization_output'
+require_relative '../../lib/decidim_zuerich/form_builder'
 
 includes = [
   [Decidim::Comments::CommentVotedEvent, DecidimZuerich::Comments::CommentVotedEvent],
   [Decidim::Debates::CreateDebateEvent,  DecidimZuerich::Debates::CreateDebateEvent],
-  [Decidim::DiffCell,                    DecidimZuerich::DiffCell]
+  [Decidim::DiffCell,                    DecidimZuerich::DiffCell],
+  [Decidim::FormBuilder,                 DecidimZuerich::FormBuilder]
 ].each { |base, addition| base.include addition }
 
 prepends = [

--- a/lib/decidim_zuerich/form_builder.rb
+++ b/lib/decidim_zuerich/form_builder.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module DecidimZuerich
+  # Fixes a problem with the javascript required validation of text input fields.
+  module FormBuilder
+    def extract_validations(attribute, options)
+      validation_options = super(attribute, options)
+
+      validation_options[:required] = options.fetch(:required, attribute_required?(attribute))
+
+      validation_options
+    end
+  end
+end

--- a/scripts/localize_database.rb
+++ b/scripts/localize_database.rb
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+exec('/usr/bin/env', 'rails', 'runner', $PROGRAM_NAME, *ARGV) unless defined?(Rails)
+
+# Prepare the Database to work well locally
+class DevEnv
+  def self.localize_hosts
+    Decidim::Organization.all.each do |org|
+      old_host = org.host
+      parts = old_host.split('.')
+      new_host = "#{parts[..-2].join('.')}.local"
+
+      org.host = new_host
+      org.save!
+      puts "Changing host '#{old_host}' to '#{new_host}'"
+    end
+  end
+
+  def self.reset_password_timers
+    # rubocop:disable Rails/SkipsModelValidations
+    Decidim::User.update_all(password_updated_at: DateTime.now)
+    # rubocop:enable Rails/SkipsModelValidations
+
+    puts 'reseting all :password_updated_at fields'
+  end
+end
+
+DevEnv.localize_hosts
+DevEnv.reset_password_timers


### PR DESCRIPTION
This is achieved by making the `required` validation disableable in FormBuilder.
Also change survey text fields to required: false, since JS validation is broken, and they get validated server-side anyway.